### PR TITLE
Removed debugging info

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,3 @@ jobs:
       uses: serverless/github-action@master
       with:
         args: deploy
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"


### PR DESCRIPTION
push to aws will still fail as using unlegit creds. That's fine for testing.